### PR TITLE
Remove complicated way of getting at local time

### DIFF
--- a/shrubgrazer.py
+++ b/shrubgrazer.py
@@ -72,10 +72,7 @@ def hide_elements(*selectors):
   return "<style>%s{display:none}</style>" % ", ".join(selectors)
 
 def epoch(timestring):
-  return int(time.mktime(
-    dateutil.parser.parse(timestring)
-    .astimezone(dateutil.tz.tzlocal())
-    .timetuple()))
+  return int(dateutil.parser.parse(timestring).timestamp())
 
 class FetchError(Exception):
   def __init__(self, response, url):


### PR DESCRIPTION
If `dateutil` parses this as a naïve time, you don't have to try to localize it at `tzlocal()`, since naïve times are already local times: https://blog.ganssle.io/articles/2022/04/naive-local-datetimes.html

Doing it this way, if `timestring` has a timezone (e.g. `2022-01-01T00:00:00-05:00`), it will give you the correct epoch time (since the `datetime` will be timezone-aware), and if it doesn't have a timezone (e.g. `2022-01-01T00:00:00`), it will be assumed to be system local time. The way you are currently doing this has the same behavior.

Also, you should probably note that `dateutil` is not part of the standard library, so this library does indeed have at least the one dependency.

Are you targeting a minimum version of Python with this? Is the format of `timestring` fixed to something specific? If the format is known it should be simple enough to write a parser function if you prefer no dependencies.